### PR TITLE
Add some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# gazebo_ros_select_joints
-Hardware interface that allows for selecting the controlled joints (unlike the standard default_robot_hw_sim which grabs all transmissions available in the model)
+# gazebo_ros_control_select_joints
+Gazebo ros_control plugin that allows for selecting the controlled joints (unlike the standard [gazebo_ros_control](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/indigo-devel/gazebo_ros_control) which grabs all transmissions available in the model)
 
 ## Usage
 The usage of this plugin is very similar to the original [gazebo_ros_control](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/indigo-devel/gazebo_ros_control) plugin, which documentation can be found [here](https://classic.gazebosim.org/tutorials?tut=ros_control)
@@ -14,4 +14,6 @@ To use the plugin, add the following to your robot's URDF:
   </gazebo>
 ```
 
-with `<joint>` being the feature brought by this package. It expects a space separated list of joint names.
+with `<joint>` tag being the feature brought by this package. It expects a space separated list of joint names.
+
+If no `<joint>` tag is specified, or if the list is empty, the plugin simply grabs all transmissions available in the model (as the standard gazebo_ros_control would do).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# gazebo_ros_select_joints_hw_interface
+# gazebo_ros_select_joints
 Hardware interface that allows for selecting the controlled joints (unlike the standard default_robot_hw_sim which grabs all transmissions available in the model)
+
+## Usage
+The usage of this plugin is very similar to the original [gazebo_ros_control](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/indigo-devel/gazebo_ros_control) plugin, which documentation can be found [here](https://classic.gazebosim.org/tutorials?tut=ros_control)
+
+To use the plugin, add the following to your robot's URDF:
+```xml
+  <gazebo>
+    <plugin name="gazebo_ros_control_select_joints" filename="libgazebo_ros_control_select_joints.so">
+      <robotNamespace>NAMESPACE</robotNamespace>
+      <joints>joint_1 joint_2 joint_3</joints>
+    </plugin>
+  </gazebo>
+```
+
+with `<joint>` being the feature brought by this package. It expects a space separated list of joint names.

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,8 @@
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/gazebo_ros_control_select_joints</url>
+  <url type="bugtracker">https://github.com/tu-darmstadt-ros-pkg/gazebo_ros_control_select_joints/issues</url>
+  <url type="repository">https://github.com/tu-darmstadt-ros-pkg/gazebo_ros_control_select_joints</url>
 
   <author>Jonathan Bohren</author>
   <author>Dave Coleman</author>


### PR DESCRIPTION
Hello,

I simply added a little a bit of documentation :
* A minimal example in the readme with some links to the `gazebo_ros_control` [repo](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/indigo-devel/gazebo_ros_control) and [documentation](https://classic.gazebosim.org/tutorials?tut=ros_control)
* The link to this repo (and bug tracker) in the package.xml, so people installing the package via conda or apt can find the source code easily.

I also plan to auto-generate the wiki page `/gazebo_ros_control_select_joints` on [wiki.ros.org](wiki.ros.org), **if** it's ok with you. (because so far the [link](https://github.com/tu-darmstadt-ros-pkg/gazebo_ros_control_select_joints/blob/b8daf2807476245c5c02a7c869b8c0487a3d4602/package.xml#L10C6-L10C6) present in the package.xml points to a non-existing page)

Cheers.